### PR TITLE
Workaround for compiling using Xcode 9 (Swift version 3.2)

### DIFF
--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -393,10 +393,10 @@ extension XML {
         // MARK :- SequenceType
         
         public func makeIterator() -> AnyIterator<Accessor> {
-            let generator: [Element]
+            let generator: [XML.Element]
             switch self {
             case .failure(_):
-                generator = [Element]()
+                generator = []
             case .singleElement(let element):
                 generator = [element]
             case .sequence(let elements):


### PR DESCRIPTION
https://github.com/yahoojapan/SwiftyXMLParser/issues/9