### PR TITLE
catching invalid character error

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ let str = """
 </ResultSet>
 """
 
-xml = try! XML.parse(string) // -> XML.Accessor
+xml = try! XML.parse(str) // -> XML.Accessor
 ```
 + from NSData
 ```swift
@@ -136,10 +136,26 @@ let str = """
 </ResultSet>
 """
 
-let data = string.dataUsingEncoding(NSUTF8StringEncoding)
+let data = str.data(using: .utf8)
 
 xml = XML.parse(data) // -> XML.Accessor
 ```
+
++ with invalid character
+
+```swift
+let srt = "<xmlopening>@ß123\u{1c}</xmlopening>"
+
+let xml = XML.parse(str.data(using: .utf8))
+
+if case .failure(XMLError.intrupptedParseError) = xml {
+  print("invalid character")
+}
+
+```
+
+For more, see https://developer.apple.com/documentation/foundation/xmlparser/errorcode 
+
 
 ### 2. Access child Elements
 ```swift

--- a/SwiftyXMLParser/Error.swift
+++ b/SwiftyXMLParser/Error.swift
@@ -25,6 +25,6 @@
 import Foundation
 
 public enum XMLError: Error {
-    case parseError
+    case failToEncodeString
     case accessError(description: String)
 }

--- a/SwiftyXMLParser/Error.swift
+++ b/SwiftyXMLParser/Error.swift
@@ -26,5 +26,6 @@ import Foundation
 
 public enum XMLError: Error {
     case failToEncodeString
+    case intrupptedParseError(rawError: Error)
     case accessError(description: String)
 }

--- a/SwiftyXMLParser/Parser.swift
+++ b/SwiftyXMLParser/Parser.swift
@@ -29,7 +29,7 @@ extension XML {
         /// If it has value, Parser is interuppted by error. (e.g. using invalid character)
         /// So the result of parsing is missing.
         /// See https://developer.apple.com/documentation/foundation/xmlparser/errorcode
-        private(set) var error: Error?
+        private(set) var error: XMLError?
         
         func parse(_ data: Data) -> Accessor {
             stack = [Element]()
@@ -37,7 +37,11 @@ extension XML {
             let parser = XMLParser(data: data)
             parser.delegate = self
             parser.parse()
-            return Accessor(documentRoot)
+            if let error = error {
+                return Accessor(error)
+            } else {
+                return Accessor(documentRoot)
+            }
         }
         
         override init() {
@@ -82,7 +86,7 @@ extension XML {
         }
         
         func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
-            error = parseError
+            error = .intrupptedParseError(rawError: parseError)
         }
     }
 }

--- a/SwiftyXMLParser/Parser.swift
+++ b/SwiftyXMLParser/Parser.swift
@@ -26,6 +26,11 @@ import Foundation
 
 extension XML {
     class Parser: NSObject, XMLParserDelegate {
+        /// If it has value, Parser is interuppted by error. (e.g. using invalid character)
+        /// So the result of parsing is missing.
+        /// See https://developer.apple.com/documentation/foundation/xmlparser/errorcode
+        private(set) var error: Error?
+        
         func parse(_ data: Data) -> Accessor {
             stack = [Element]()
             stack.append(documentRoot)
@@ -74,6 +79,10 @@ extension XML {
                 stack.last?.text = stack.last?.text?.trimmingCharacters(in: trimmingManner)
             }
             stack.removeLast()
+        }
+        
+        func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
+            error = parseError
         }
     }
 }

--- a/SwiftyXMLParser/XML.swift
+++ b/SwiftyXMLParser/XML.swift
@@ -104,7 +104,7 @@ open class XML {
      */
     open class func parse(_ str: String) throws -> Accessor {
         guard let data = str.data(using: String.Encoding.utf8) else {
-            throw XMLError.parseError
+            throw XMLError.failToEncodeString
         }
         
         return Parser().parse(data)
@@ -130,7 +130,7 @@ open class XML {
      */
     open class func parse(_ str: String, trimming manner: CharacterSet) throws -> Accessor {
         guard let data = str.data(using: String.Encoding.utf8) else {
-            throw XMLError.parseError
+            throw XMLError.failToEncodeString
         }
         
         return Parser(trimming: manner).parse(data)

--- a/SwiftyXMLParserTests/ParserTests.swift
+++ b/SwiftyXMLParserTests/ParserTests.swift
@@ -61,10 +61,10 @@ class ParserTests: XCTestCase {
         }
         
         let xml = XML.Parser().parse(data)
-        if let _ = xml["ResultSet"].error {
-            XCTFail("fail to parse")
+        if case .failure(XMLError.intrupptedParseError) = xml {
+            XCTAssert(true, "Parsed Failure because of the invalid character")
         } else {
-            XCTAssert(true, "success to parse")
+            XCTAssert(false, "fail")
         }
     }
     
@@ -142,5 +142,22 @@ class ParserTests: XCTestCase {
         } else {
             XCTAssert(false, "fail")
         }
-    }    
+    }
+    
+    func testParseErrorToInvalidCharacter() {
+        let str = "<xmlopening>@ß123\u{1c}</xmlopening>"
+        let xml = XML.Parser().parse(str.data(using: .utf8)!)
+        
+        if case .failure(XMLError.intrupptedParseError) = xml {
+            XCTAssert(true, "Parsed Failure because of the invalid character")
+        } else {
+            XCTAssert(false, "fail")
+        }
+    }
+    
+    func testNotParseErrorToInvalidCharacter() {
+        let str = "<xmlopening>@ß123\u{1c}</xmlopening>".addingPercentEncoding(withAllowedCharacters: CharacterSet.controlCharacters.inverted)!
+        let xml = XML.Parser().parse(str.data(using: .utf8)!)
+        XCTAssertEqual("@ß123\u{1c}", xml["xmlopening"].text?.removingPercentEncoding, "Parsed Success and trim them")
+    }
 }

--- a/SwiftyXMLParserTests/XMLTests.swift
+++ b/SwiftyXMLParserTests/XMLTests.swift
@@ -70,7 +70,7 @@ class XMLTests: XCTestCase {
     
     
     func testSuccessParseFromDoublebyteSpace() {
-        guard let xml = try? XML.parse("<Name>　<Name>") else {
+        guard let xml = try? XML.parse("<Name>　</Name>") else {
             XCTFail("Fail Prase")
             return
         }


### PR DESCRIPTION
SwiftyXMLParser doesn't catch parsing error. It is inconvenience. 
So I added error delegate in XML.Parser.

https://github.com/yahoojapan/SwiftyXMLParser/issues/26
https://github.com/yahoojapan/SwiftyXMLParser/issues/25