### PR TITLE
Test target update to Swift 4.2

### DIFF
--- a/SwiftyXMLParser.xcodeproj/project.pbxproj
+++ b/SwiftyXMLParser.xcodeproj/project.pbxproj
@@ -428,7 +428,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = jp.co.yahoo.shopping.SwiftyXMLParserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -440,7 +440,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = jp.co.yahoo.shopping.SwiftyXMLParserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/SwiftyXMLParserTests/AccessorTests.swift
+++ b/SwiftyXMLParserTests/AccessorTests.swift
@@ -332,15 +332,15 @@ class AccessorTests: XCTestCase {
     
     func testFlatMap() {
         let accessor = XML.Accessor(singleElement())
-        let singleText = accessor.flatMap { $0.text }
+        let singleText = accessor.compactMap { $0.text }
         XCTAssertEqual(singleText, ["text"], "can access text")
         
         let sequenceAccessor = XML.Accessor(sequence())
-        let texts = sequenceAccessor.flatMap { $0.text }
+        let texts = sequenceAccessor.compactMap { $0.text }
         XCTAssertEqual(texts, ["text", "text2"], "can access each text")
         
         let failureAccessor = XML.Accessor(failure())
-        let failureTexts = failureAccessor.flatMap { $0.text }
+        let failureTexts = failureAccessor.compactMap { $0.text }
         XCTAssertEqual(failureTexts, [], "has no text")
     }
     


### PR DESCRIPTION
Hi,

I update Test target Swift version to 4.2.
and fix warning of “flatmap deprecated”.

Regards.