### PR TITLE
Fix “MARK:” syntax and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ let srt = "<xmlopening>@ß123\u{1c}</xmlopening>"
 
 let xml = XML.parse(str.data(using: .utf8))
 
-if case .failure(XMLError.intrupptedParseError) = xml {
+if case .failure(XMLError.interruptedParseError) = xml {
   print("invalid character")
 }
 
@@ -259,7 +259,7 @@ Alamofire.request(.GET, "https://itunes.apple.com/us/rss/topgrossingapplications
         }
 ```
 
-In addition, there is the extension of Alamofire to combine with SwiftyXMLPraser. 
+In addition, there is the extension of Alamofire to combine with SwiftyXMLParser. 
 
 * [Alamofire-SwiftyXMLParser](https://github.com/kazuhiro4949/Alamofire-SwiftyXMLParser)
 

--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -396,7 +396,7 @@ extension XML {
             }
         }
 
-        // MARK :- SequenceType
+        // MARK: - SequenceType
         
         public func makeIterator() -> AnyIterator<Accessor> {
             let generator: [XML.Element]

--- a/SwiftyXMLParser/Error.swift
+++ b/SwiftyXMLParser/Error.swift
@@ -26,6 +26,6 @@ import Foundation
 
 public enum XMLError: Error {
     case failToEncodeString
-    case intrupptedParseError(rawError: Error)
+    case interruptedParseError(rawError: Error)
     case accessError(description: String)
 }

--- a/SwiftyXMLParser/Parser.swift
+++ b/SwiftyXMLParser/Parser.swift
@@ -86,7 +86,7 @@ extension XML {
         }
         
         func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
-            error = .intrupptedParseError(rawError: parseError)
+            error = .interruptedParseError(rawError: parseError)
         }
     }
 }

--- a/SwiftyXMLParserTests/CustomOperatorTests.swift
+++ b/SwiftyXMLParserTests/CustomOperatorTests.swift
@@ -37,7 +37,7 @@ class CustomOperatorTests: XCTestCase {
         super.tearDown()
     }
 
-    // MAKR:- ?=のテスト
+    // MARK: - ?=のテスト
     func testFailableAssignment() {
         let optionalSome: Int? = 1
         var targetSome: Int = 0

--- a/SwiftyXMLParserTests/ParserTests.swift
+++ b/SwiftyXMLParserTests/ParserTests.swift
@@ -61,7 +61,7 @@ class ParserTests: XCTestCase {
         }
         
         let xml = XML.Parser().parse(data)
-        if case .failure(XMLError.intrupptedParseError) = xml {
+        if case .failure(XMLError.interruptedParseError) = xml {
             XCTAssert(true, "Parsed Failure because of the invalid character")
         } else {
             XCTAssert(false, "fail")
@@ -148,7 +148,7 @@ class ParserTests: XCTestCase {
         let str = "<xmlopening>@ß123\u{1c}</xmlopening>"
         let xml = XML.Parser().parse(str.data(using: .utf8)!)
         
-        if case .failure(XMLError.intrupptedParseError) = xml {
+        if case .failure(XMLError.interruptedParseError) = xml {
             XCTAssert(true, "Parsed Failure because of the invalid character")
         } else {
             XCTAssert(false, "fail")

--- a/SwiftyXMLParserTests/XMLTests.swift
+++ b/SwiftyXMLParserTests/XMLTests.swift
@@ -71,14 +71,14 @@ class XMLTests: XCTestCase {
     
     func testSuccessParseFromDoublebyteSpace() {
         guard let xml = try? XML.parse("<Name>　</Name>") else {
-            XCTFail("Fail Prase")
+            XCTFail("Fail Parse")
             return
         }
         
         if  let name = xml["Name"].text {
             XCTAssertEqual(name, "　", "Parse Success Double-byte Space")
         } else {
-            XCTFail("Fail Prase")
+            XCTFail("Fail Parse")
         }
     }
 


### PR DESCRIPTION
Hi,

I found “MARK:” syntax miss and typo.

Regards.
