### PR TITLE
Add Linux support

### DIFF
--- a/SwiftyXMLParser/Parser.swift
+++ b/SwiftyXMLParser/Parser.swift
@@ -23,6 +23,9 @@
  */
 
 import Foundation
+#if canImport(FoundationXML)
+    import FoundationXML
+#endif
 
 extension XML {
     class Parser: NSObject, XMLParserDelegate {


### PR DESCRIPTION
I was getting these errors before on swift 5.3 images:

```
.build/checkouts/SwiftyXMLParser/SwiftyXMLParser/Parser.swift:60:31: error: 'XMLParser' is unavailable: This type has moved to the FoundationXML module. Import that module to use it.
        func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String]) {
                              ^~~~~~~~~
Foundation.XMLParser:2:18: note: 'XMLParser' has been explicitly marked unavailable here
public typealias XMLParser = AnyObject
                 ^
.build/checkouts/SwiftyXMLParser/SwiftyXMLParser/Parser.swift:73:31: error: 'XMLParser' is unavailable: This type has moved to the FoundationXML module. Import that module to use it.
        func parser(_ parser: XMLParser, foundCharacters string: String) {
                              ^~~~~~~~~
Foundation.XMLParser:2:18: note: 'XMLParser' has been explicitly marked unavailable here
public typealias XMLParser = AnyObject
                 ^
.build/checkouts/SwiftyXMLParser/SwiftyXMLParser/Parser.swift:81:31: error: 'XMLParser' is unavailable: This type has moved to the FoundationXML module. Import that module to use it.
        func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
                              ^~~~~~~~~
Foundation.XMLParser:2:18: note: 'XMLParser' has been explicitly marked unavailable here
public typealias XMLParser = AnyObject
                 ^
.build/checkouts/SwiftyXMLParser/SwiftyXMLParser/Parser.swift:88:31: error: 'XMLParser' is unavailable: This type has moved to the FoundationXML module. Import that module to use it.
        func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
                              ^~~~~~~~~
Foundation.XMLParser:2:18: note: 'XMLParser' has been explicitly marked unavailable here
public typealias XMLParser = AnyObject
                 ^
.build/checkouts/SwiftyXMLParser/SwiftyXMLParser/Parser.swift:28:29: error: cannot find type 'XMLParserDelegate' in scope
    class Parser: NSObject, XMLParserDelegate {
                            ^~~~~~~~~~~~~~~~~
.build/checkouts/SwiftyXMLParser/SwiftyXMLParser/Parser.swift:37:26: error: 'XMLParser' is unavailable: This type has moved to the FoundationXML module. Import that module to use it.
            let parser = XMLParser(data: data)
                         ^~~~~~~~~
Foundation.XMLParser:2:18: note: 'XMLParser' has been explicitly marked unavailable here
public typealias XMLParser = AnyObject
```