### PR TITLE
Feature: Set text, append element and ignore namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ DerivedData/
 !default.perspectivev3
 
 
+
+SwiftyXMLParser.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/SwiftyXMLParser.podspec
+++ b/SwiftyXMLParser.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftyXMLParser"
-  s.version      = "5.3.0"
+  s.version      = "5.4.0"
   s.summary      = "Simple XML Parser implemented by Swift"
 
   s.description  = <<-DESC
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
   s.source_files = "SwiftyXMLParser/*.swift"
   s.requires_arc = true
 
-  s.source       = { :git => "https://github.com/yahoojapan/SwiftyXMLParser.git", :tag => "5.3.0" }
+  s.source       = { :git => "https://github.com/yahoojapan/SwiftyXMLParser.git", :tag => "5.4.0" }
 end

--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -412,6 +412,15 @@ extension XML {
             }
         }
 
+        public func append(_ newElement: Element) {
+            switch self {
+            case .singleElement(let element):
+                element.childElements.append(newElement)
+            default:
+                break
+            }
+        }
+
         // MARK: - SequenceType
         
         public func makeIterator() -> AnyIterator<Accessor> {

--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -129,7 +129,7 @@ extension XML {
             switch self {
             case .singleElement(let element):
                 let filterdElements = element.childElements.filter {
-                    if XML.ignoreNamespaces {
+                    if element.ignoreNamespaces {
                         return key == $0.name.components(separatedBy: ":").last ?? $0.name
                     } else {
                         return key == $0.name

--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -507,7 +507,7 @@ extension XML {
         private func traverse(_ element: Element) -> String {
             let name = element.name
             let text = element.text ?? ""
-            let attrs = element.attributes.map { (k, v) in "\(k)=\"\(v)\""  }.joined(separator: " ")
+            let attrs = element.attributes.map { (k, v) in "\(k)=\"\(v)\"" }.joined(separator: " ")
 
             let childDocs = element.childElements.reduce("", { (result, element) in
                 result + traverse(element)
@@ -516,7 +516,7 @@ extension XML {
             if name == "XML.Parser.AbstructedDocumentRoot" {
                 return childDocs
             } else {
-                return "<\(name) \(attrs)>\(text)\(childDocs)</\(name)>"
+                return "<\(name)\(attrs.isEmpty ? "" : " ")\(attrs)>\(text)\(childDocs)</\(name)>"
             }
         }
     }

--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -128,29 +128,26 @@ extension XML {
             let accessor: Accessor
             switch self {
             case .singleElement(let element):
-                let filterdElements = element.childElements.filter {
-                    if element.ignoreNamespaces {
+                let childElements = element.childElements.filter {
+                    if $0.ignoreNamespaces {
                         return key == $0.name.components(separatedBy: ":").last ?? $0.name
                     } else {
                         return key == $0.name
                     }
                 }
-                if filterdElements.isEmpty {
+                if childElements.isEmpty {
                     let error = accessError("\(key) not found.")
-                    accessor =  Accessor(error)
-                } else if filterdElements.count == 1 {
-                    accessor =  Accessor(filterdElements[0])
+                    accessor = Accessor(error)
+                } else if childElements.count == 1 {
+                    accessor = Accessor(childElements[0])
                 } else {
-                    accessor =  Accessor(filterdElements)
+                    accessor = Accessor(childElements)
                 }
             case .failure(let error):
-                accessor =  Accessor(error)
-            case .sequence(_):
-                fallthrough
+                accessor = Accessor(error)
             default:
                 let error = accessError("cannot access \(key), because of multiple elements")
-                accessor =  Accessor(error)
-                break
+                accessor = Accessor(error)
             }
             return accessor
         }

--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -283,19 +283,24 @@ extension XML {
             return text.flatMap({Double($0)})
         }
         
-        /// access to XML Attributes
+        /// get and set XML attributes on single element
         public var attributes: [String: String] {
-            let attributes: [String: String]
-            switch self {
-            case .singleElement(let element):
-                attributes = element.attributes
-            case .failure(_), .sequence(_):
-                fallthrough
-            default:
-                attributes = [String: String]()
-                break
+            get {
+                switch self {
+                case .singleElement(let element):
+                    return element.attributes
+                default:
+                    return [String: String]()
+                }
             }
-            return attributes
+            set {
+                switch self {
+                case .singleElement(let element):
+                    element.attributes = newValue
+                default:
+                    break
+                }
+            }
         }
         
         /// access to child Elements

--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -128,7 +128,13 @@ extension XML {
             let accessor: Accessor
             switch self {
             case .singleElement(let element):
-                let filterdElements = element.childElements.filter { $0.name == key }
+                let filterdElements = element.childElements.filter {
+                    if XML.ignoreNamespaces {
+                        return key == $0.name.components(separatedBy: ":").last ?? $0.name
+                    } else {
+                        return key == $0.name
+                    }
+                }
                 if filterdElements.isEmpty {
                     let error = accessError("\(key) not found.")
                     accessor =  Accessor(error)

--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -235,21 +235,26 @@ extension XML {
             }
             return name
         }
-        
+
+        /// get and set text on single element
         public var text: String? {
-            let text: String?
-            switch self {
-            case .singleElement(let element):
-                text = element.text
-            case .failure(_), .sequence(_):
-                fallthrough
-            default:
-                text = nil
-                break
+            get {
+                switch self {
+                case .singleElement(let element):
+                    return element.text
+                default:
+                    return nil
+                }
             }
-            return text
+            set {
+                switch self {
+                case .singleElement(let element):
+                    element.text = newValue
+                default:
+                    break
+                }
+            }
         }
-        
         
         /// syntax sugar to access Bool Text
         public var bool: Bool? {

--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -462,7 +462,7 @@ extension XML {
 }
 
 extension XML {
-    /// Conveter to make xml document from Accessor.
+    /// Converter to make xml document from Accessor.
     public class Converter {
         let accessor: XML.Accessor
 
@@ -471,7 +471,9 @@ extension XML {
         }
         
         /**
-         If Accessor object has correct XML path, return the XML element, otherwith return error
+         Convert accessor back to XML document string.
+
+         - Parameter withDeclaration:Prefix with standard XML declaration (default true)
          
          example:
          
@@ -484,12 +486,12 @@ extension XML {
          ```
          
          */
-        public func makeDocument() throws -> String {
+        public func makeDocument(withDeclaration: Bool = true) throws -> String {
             if case .failure(let err) = accessor {
                 throw err
             }
 
-            var doc: String = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            var doc = withDeclaration ? "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" : ""
             for hit in accessor {
                 switch hit {
                 case .singleElement(let element):

--- a/SwiftyXMLParser/Element.swift
+++ b/SwiftyXMLParser/Element.swift
@@ -28,14 +28,17 @@ extension XML {
     open class Element {
         open var name: String
         open var text: String?
-        open var attributes = [String: String]()
-        open var childElements = [Element]()
+        open var attributes: [String: String]
+        open var childElements: [Element]
         
         // for println
         open weak var parentElement: Element?
         
-        public init(name: String) {
+        public init(name: String, text: String? = nil, attributes: [String: String] = [:], childElements: [Element] = []) {
             self.name = name
+            self.text = text
+            self.attributes = attributes
+            self.childElements = childElements
         }
     }
 }

--- a/SwiftyXMLParser/Element.swift
+++ b/SwiftyXMLParser/Element.swift
@@ -28,20 +28,34 @@ extension XML {
     open class Element {
         open var name: String
         open var text: String?
-        open var attributes = [String: String]()
-        open var childElements = [Element]()
-        open var lineNumberStart = -1
-        open var lineNumberEnd = -1
+        open var attributes: [String: String]
+        open var childElements: [Element]
+        open var lineNumberStart: Int
+        open var lineNumberEnd: Int
         open var CDATA: Data?
+        open var ignoreNamespaces: Bool
         
         // for println
         open weak var parentElement: Element?
-        
-        public init(name: String, text: String? = nil, attributes: [String: String] = [:], childElements: [Element] = []) {
+
+        public init(
+            name: String,
+            text: String? = nil,
+            attributes: [String: String] = [:],
+            childElements: [Element] = [],
+            lineNumberStart: Int = -1,
+            lineNumberEnd: Int = -1,
+            CDATA: Data? = nil,
+            ignoreNamespaces: Bool = false
+        ) {
             self.name = name
             self.text = text
             self.attributes = attributes
             self.childElements = childElements
+            self.lineNumberStart = lineNumberStart
+            self.lineNumberEnd = lineNumberEnd
+            self.CDATA = CDATA
+            self.ignoreNamespaces = ignoreNamespaces
         }
     }
 }

--- a/SwiftyXMLParser/Parser.swift
+++ b/SwiftyXMLParser/Parser.swift
@@ -33,7 +33,7 @@ extension XML {
         /// So the result of parsing is missing.
         /// See https://developer.apple.com/documentation/foundation/xmlparser/errorcode
         private(set) var error: XMLError?
-        
+
         func parse(_ data: Data) -> Accessor {
             stack = [Element]()
             stack.append(documentRoot)
@@ -46,22 +46,21 @@ extension XML {
                 return Accessor(documentRoot)
             }
         }
-        
-        override init() {
-            trimmingManner = nil
-        }
-        
-        init(trimming manner: CharacterSet) {
-            trimmingManner = manner
+
+        init(trimming manner: CharacterSet? = nil, ignoreNamespaces: Bool = false) {
+            self.trimmingManner = manner
+            self.ignoreNamespaces = ignoreNamespaces
+            self.documentRoot = Element(name: "XML.Parser.AbstructedDocumentRoot", ignoreNamespaces: ignoreNamespaces)
         }
         
         // MARK:- private
-        fileprivate var documentRoot = Element(name: "XML.Parser.AbstructedDocumentRoot")
+        fileprivate var documentRoot: Element
         fileprivate var stack = [Element]()
         fileprivate let trimmingManner: CharacterSet?
+        fileprivate let ignoreNamespaces: Bool
         
         func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String]) {
-            let node = Element(name: elementName)
+            let node = Element(name: elementName, ignoreNamespaces: ignoreNamespaces)
             node.lineNumberStart = parser.lineNumber
             if !attributeDict.isEmpty {
                 node.attributes = attributeDict

--- a/SwiftyXMLParser/XML.swift
+++ b/SwiftyXMLParser/XML.swift
@@ -142,8 +142,15 @@ open class XML {
         
         return Parser(trimming: manner).parse(data)
     }
-    
-    open class func document(_ accessor: Accessor) throws -> String {
-        return try Converter(accessor).makeDocument()
+
+    /**
+     Convert accessor back to XML document string.
+
+     - Parameter accessor:XML accessor
+     - Parameter withDeclaration:Prefix with standard XML declaration (default true)
+     - Returns:XML document string
+     */
+    open class func document(_ accessor: Accessor, withDeclaration: Bool = true) throws -> String {
+        return try Converter(accessor).makeDocument(withDeclaration: withDeclaration)
     }
 }

--- a/SwiftyXMLParser/XML.swift
+++ b/SwiftyXMLParser/XML.swift
@@ -86,6 +86,13 @@ public func ?<< <T>(lhs: inout [T], rhs: T?) {
  ```
 */
 open class XML {
+
+    /**
+    Global XML setting for ignoring namespaces.
+    If set to true all accessors will ignore the first part of an element name up to a semicolon (:).
+     */
+    static var ignoreNamespaces = false
+
     /**
     Interface to parse NSData
     

--- a/SwiftyXMLParser/XML.swift
+++ b/SwiftyXMLParser/XML.swift
@@ -91,7 +91,7 @@ open class XML {
     Global XML setting for ignoring namespaces.
     If set to true all accessors will ignore the first part of an element name up to a semicolon (:).
      */
-    static var ignoreNamespaces = false
+    public static var ignoreNamespaces = false
 
     /**
     Interface to parse NSData

--- a/SwiftyXMLParser/XML.swift
+++ b/SwiftyXMLParser/XML.swift
@@ -88,67 +88,39 @@ public func ?<< <T>(lhs: inout [T], rhs: T?) {
 open class XML {
 
     /**
-    Global XML setting for ignoring namespaces.
-    If set to true all accessors will ignore the first part of an element name up to a semicolon (:).
-     */
-    public static var ignoreNamespaces = false
-
-    /**
-    Interface to parse NSData
-    
-    - parameter data:NSData XML document
-    - returns:Accessor object to access XML document
-    */
-    open class func parse(_ data: Data) -> Accessor {
-        return Parser().parse(data)
-    }
-    
-    /**
-     Interface to parse String
+     Interface to parse Data
      
-     - Parameter str:String XML document
-     - Returns:Accessor object to access XML document
-     */
-    open class func parse(_ str: String) throws -> Accessor {
-        guard let data = str.data(using: String.Encoding.utf8) else {
-            throw XMLError.failToEncodeString
-        }
-        
-        return Parser().parse(data)
-    }
-    
-    /**
-     Interface to parse NSData
-     
-     - parameter data:NSData XML document
-     - parameter manner:NSCharacterSet If you wannna trim Text, assign this arg
+     - parameter data:Data XML document
+     - parameter manner:CharacterSet If you want to trim text (default off)
+     - parameter ignoreNamespaces:Bool If set to true all accessors will ignore the first part of an element name up to a semicolon (default false)
      - returns:Accessor object to access XML document
      */
-    open class func parse(_ data: Data, trimming manner: CharacterSet) -> Accessor {
-        return Parser(trimming: manner).parse(data)
+    open class func parse(_ data: Data, trimming manner: CharacterSet? = nil, ignoreNamespaces: Bool = false) -> Accessor {
+        return Parser(trimming: manner, ignoreNamespaces: ignoreNamespaces).parse(data)
     }
     
     /**
      Interface to parse String
      
-     - Parameter str:String XML document
-     - parameter manner:NSCharacterSet If you wannna trim Text, assign this arg
-     - Returns:Accessor object to access XML document
+     - parameter str:String XML document
+     - parameter manner:CharacterSet If you want to trim text (default off)
+     - parameter ignoreNamespaces:Bool If set to true all accessors will ignore the first part of an element name up to a semicolon (default false)
+     - returns:Accessor object to access XML document
      */
-    open class func parse(_ str: String, trimming manner: CharacterSet) throws -> Accessor {
+    open class func parse(_ str: String, trimming manner: CharacterSet? = nil, ignoreNamespaces: Bool = false) throws -> Accessor {
         guard let data = str.data(using: String.Encoding.utf8) else {
             throw XMLError.failToEncodeString
         }
         
-        return Parser(trimming: manner).parse(data)
+        return Parser(trimming: manner, ignoreNamespaces: ignoreNamespaces).parse(data)
     }
 
     /**
      Convert accessor back to XML document string.
 
-     - Parameter accessor:XML accessor
-     - Parameter withDeclaration:Prefix with standard XML declaration (default true)
-     - Returns:XML document string
+     - parameter accessor:XML accessor
+     - parameter withDeclaration:Prefix with standard XML declaration (default true)
+     - returns:XML document string
      */
     open class func document(_ accessor: Accessor, withDeclaration: Bool = true) throws -> String {
         return try Converter(accessor).makeDocument(withDeclaration: withDeclaration)

--- a/SwiftyXMLParserTests/AccessorTests.swift
+++ b/SwiftyXMLParserTests/AccessorTests.swift
@@ -238,7 +238,7 @@ class AccessorTests: XCTestCase {
 
         XCTAssertEqual(
             try XML.document(accessor),
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RootElement key=\"value\">text2<ChildElement >childText1</ChildElement><ChildElement >childText2</ChildElement></RootElement>",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RootElement key=\"value\">text2<ChildElement>childText1</ChildElement><ChildElement>childText2</ChildElement></RootElement>",
             "end document has newly added texts"
         )
 
@@ -268,7 +268,7 @@ class AccessorTests: XCTestCase {
 
         XCTAssertEqual(
             try XML.document(sequenceAccessor),
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Element key=\"value\">newText<ChildElement1 >childText1</ChildElement1><ChildElement1 >childText2</ChildElement1></Element><Element >newText2<ChildElement2 ></ChildElement2><ChildElement2 ></ChildElement2></Element>",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Element key=\"value\">newText<ChildElement1>childText1</ChildElement1><ChildElement1>childText2</ChildElement1></Element><Element>newText2<ChildElement2></ChildElement2><ChildElement2></ChildElement2></Element>",
             "end document has newly added texts"
         )
     }
@@ -414,7 +414,7 @@ class AccessorTests: XCTestCase {
 
         XCTAssertEqual(
             try XML.document(accessor),
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><env:RootElement key=\"value\">text<ns1:ChildElement >childText1</ns1:ChildElement><ns2:ChildElement >childText2</ns2:ChildElement></env:RootElement>",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><env:RootElement key=\"value\">text<ns1:ChildElement>childText1</ns1:ChildElement><ns2:ChildElement>childText2</ns2:ChildElement></env:RootElement>",
             "end document preserves elements with namespaces"
         )
     }

--- a/SwiftyXMLParserTests/AccessorTests.swift
+++ b/SwiftyXMLParserTests/AccessorTests.swift
@@ -221,6 +221,56 @@ class AccessorTests: XCTestCase {
             XCTAssert(true, "fail to access name with Failure Accessor")
         }
     }
+
+    func testSetText() throws {
+        var accessor = XML.Accessor(singleElement())
+        accessor.text = "text2"
+        XCTAssertEqual(accessor.text, "text2", "set text on first single element")
+
+        var element = accessor["ChildElement"].first
+        element.text = "childText1"
+        XCTAssertEqual(element.text, "childText1", "set text for first child element")
+
+        element = accessor["ChildElement"].last
+        element.text = "childText2"
+        XCTAssertEqual(element.text, "childText2", "set text for last child element")
+
+        XCTAssertEqual(
+            try XML.document(accessor),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RootElement key=\"value\">text2<ChildElement >childText1</ChildElement><ChildElement >childText2</ChildElement></RootElement>",
+            "end document has newly added texts"
+        )
+
+        var sequenceAccessor = XML.Accessor(sequence())
+        sequenceAccessor.text = "text"
+        XCTAssertEqual(sequenceAccessor.text, nil, "cannot set text on sequence")
+
+        var accessorElement = sequenceAccessor.first
+        accessorElement.text = "newText"
+        XCTAssertEqual(accessorElement.text, "newText", "set text for first element in sequence")
+
+        accessorElement = sequenceAccessor.last
+        accessorElement.text = "newText2"
+        XCTAssertEqual(accessorElement.text, "newText2", "set text for last element in sequence")
+
+        accessorElement = sequenceAccessor.first["ChildElement1"]
+        accessorElement.text = "childText"
+        XCTAssertEqual(accessorElement.text, nil, "cannot set text for sequence")
+
+        accessorElement = sequenceAccessor.first["ChildElement1"].first
+        accessorElement.text = "childText1"
+        XCTAssertEqual(accessorElement.text, "childText1", "set text for first element of first child")
+
+        accessorElement = sequenceAccessor.first["ChildElement1"].last
+        accessorElement.text = "childText2"
+        XCTAssertEqual(accessorElement.text, "childText2", "set text for last element of first child")
+
+        XCTAssertEqual(
+            try XML.document(sequenceAccessor),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Element key=\"value\">newText<ChildElement1 >childText1</ChildElement1><ChildElement1 >childText2</ChildElement1></Element><Element >newText2<ChildElement2 ></ChildElement2><ChildElement2 ></ChildElement2></Element>",
+            "end document has newly added texts"
+        )
+    }
     
     func testAttributes() {
         let accessor = XML.Accessor(singleElement())

--- a/SwiftyXMLParserTests/AccessorTests.swift
+++ b/SwiftyXMLParserTests/AccessorTests.swift
@@ -505,52 +505,37 @@ class AccessorTests: XCTestCase {
     }
     
     fileprivate func singleElement() -> XML.Element {
-        let element = XML.Element(name: "RootElement")
-        element.text = "text"
-        element.attributes = ["key": "value"]
-        element.childElements = [
+        return XML.Element(name: "RootElement", text: "text", attributes: ["key": "value"], childElements: [
             XML.Element(name: "ChildElement"),
             XML.Element(name: "ChildElement")
-        ]
-        return element
+        ])
     }
 
     fileprivate func singleElementWithNamespaces() -> XML.Element {
-        let element = XML.Element(name: "env:RootElement")
-        element.text = "text"
-        element.attributes = ["key": "value"]
-        element.childElements = [
+        return XML.Element(name: "env:RootElement", text: "text", attributes: ["key": "value"], childElements: [
             XML.Element(name: "ns1:ChildElement", text: "childText1"),
             XML.Element(name: "ns2:ChildElement", text: "childText2"),
-        ]
-        return element
+        ])
     }
 
     fileprivate func singleElementWithChildrenAttributes() -> XML.Element {
-        let element = XML.Element(name: "RootElement")
-        element.childElements = [
+        return XML.Element(name: "RootElement", childElements: [
             XML.Element(name: "ChildElement1", attributes: ["key1": "value1"]),
             XML.Element(name: "ChildElement2", attributes: ["key2": "value2"])
-        ]
-        return element
+        ])
     }
     
     fileprivate func sequence() -> [XML.Element] {
-        let elem1 = XML.Element(name: "Element")
-        elem1.text = "text"
-        elem1.attributes = ["key": "value"]
-        elem1.childElements = [
-            XML.Element(name: "ChildElement1"),
-            XML.Element(name: "ChildElement1")
+        return [
+            XML.Element(name: "Element", text: "text", attributes: ["key": "value"], childElements: [
+                XML.Element(name: "ChildElement1"),
+                XML.Element(name: "ChildElement1")
+            ]),
+            XML.Element(name: "Element", text: "text2", childElements: [
+                XML.Element(name: "ChildElement2"),
+                XML.Element(name: "ChildElement2")
+            ])
         ]
-        let elem2 = XML.Element(name: "Element")
-        elem2.text = "text2"
-        elem2.childElements = [
-            XML.Element(name: "ChildElement2"),
-            XML.Element(name: "ChildElement2")
-        ]
-        let elements = [ elem1, elem2 ]
-        return elements
     }
     
     fileprivate func failure() -> XMLError {

--- a/SwiftyXMLParserTests/AccessorTests.swift
+++ b/SwiftyXMLParserTests/AccessorTests.swift
@@ -295,6 +295,41 @@ class AccessorTests: XCTestCase {
             XCTAssert(true, "fail to access name with Failure Accessor")
         }
     }
+
+    func testSetAttributes() throws {
+        var accessor = XML.Accessor(singleElement())
+        accessor.attributes = ["key": "newValue"]
+        XCTAssertEqual(accessor.attributes, ["key": "newValue"], "edit attribute on first single element")
+
+        var element = accessor["ChildElement"].first
+        element.attributes = ["key": "childAttribute1"]
+        XCTAssertEqual(element.attributes, ["key": "childAttribute1"], "set attribute for first child element")
+
+        element = accessor["ChildElement"].last
+        element.attributes = ["key": "childAttribute2"]
+        XCTAssertEqual(element.attributes, ["key": "childAttribute2"], "set attribute for last child element")
+
+        XCTAssertEqual(
+            try XML.document(accessor),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RootElement key=\"newValue\">text<ChildElement key=\"childAttribute1\"></ChildElement><ChildElement key=\"childAttribute2\"></ChildElement></RootElement>",
+            "end document has updated attributes"
+        )
+
+        let accessor2 = XML.Accessor(singleElementWithChildrenAttributes())
+        var element2 = accessor2["ChildElement1"]
+        element2.attributes["key1"] = "newValue1"
+        XCTAssertEqual(element2.attributes, ["key1": "newValue1"], "edit attribute for child element")
+
+        element2 = accessor2["ChildElement2"]
+        element2.attributes["key2"] = "newValue2"
+        XCTAssertEqual(element2.attributes, ["key2": "newValue2"], "edit attribute for child element")
+
+        XCTAssertEqual(
+            try XML.document(accessor2),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RootElement><ChildElement1 key1=\"newValue1\"></ChildElement1><ChildElement2 key2=\"newValue2\"></ChildElement2></RootElement>",
+            "end document has updated attributes"
+        )
+    }
     
     func testAll() {
         let accessor = XML.Accessor(singleElement())
@@ -460,6 +495,15 @@ class AccessorTests: XCTestCase {
         element.childElements = [
             XML.Element(name: "ns1:ChildElement", text: "childText1"),
             XML.Element(name: "ns2:ChildElement", text: "childText2"),
+        ]
+        return element
+    }
+
+    fileprivate func singleElementWithChildrenAttributes() -> XML.Element {
+        let element = XML.Element(name: "RootElement")
+        element.childElements = [
+            XML.Element(name: "ChildElement1", attributes: ["key1": "value1"]),
+            XML.Element(name: "ChildElement2", attributes: ["key2": "value2"])
         ]
         return element
     }

--- a/SwiftyXMLParserTests/AccessorTests.swift
+++ b/SwiftyXMLParserTests/AccessorTests.swift
@@ -453,6 +453,33 @@ class AccessorTests: XCTestCase {
             "end document preserves elements with namespaces"
         )
     }
+
+    func testAppend() throws {
+        let accessor = XML.Accessor(singleElement())
+
+        XCTAssertEqual(accessor["RootElement"].text, nil)
+
+        accessor.append(singleElement())
+        XCTAssertEqual(accessor["RootElement"].text, "text")
+
+        XCTAssertEqual(
+            try XML.document(accessor),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RootElement key=\"value\">text<ChildElement></ChildElement><ChildElement></ChildElement><RootElement key=\"value\">text<ChildElement></ChildElement><ChildElement></ChildElement></RootElement></RootElement>",
+            "end document has added element"
+        )
+
+        let accessor2 = XML.Accessor(singleElement())
+
+        accessor2["ChildElement"].first.append(singleElementWithChildrenAttributes())
+        XCTAssertEqual(accessor2["ChildElement"].first["RootElement", "ChildElement1"].attributes, ["key1": "value1"])
+        XCTAssertEqual(accessor2["ChildElement"].first["RootElement", "ChildElement2"].attributes, ["key2": "value2"])
+
+        XCTAssertEqual(
+            try XML.document(accessor2),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RootElement key=\"value\">text<ChildElement><RootElement><ChildElement1 key1=\"value1\"></ChildElement1><ChildElement2 key2=\"value2\"></ChildElement2></RootElement></ChildElement><ChildElement></ChildElement></RootElement>",
+            "end document has added element"
+        )
+    }
     
     func testIterator() {
         let accessor = XML.Accessor(singleElement())

--- a/SwiftyXMLParserTests/AccessorTests.swift
+++ b/SwiftyXMLParserTests/AccessorTests.swift
@@ -28,7 +28,6 @@ import XCTest
 class AccessorTests: XCTestCase {
 
     override func setUp() {
-        XML.ignoreNamespaces = false
         super.setUp()
     }
     
@@ -430,30 +429,6 @@ class AccessorTests: XCTestCase {
         XCTAssertEqual(failureTexts, [], "has no text")
     }
 
-    func testIgnoreNamespaces() throws {
-        let accessor = XML.Accessor(singleElementWithNamespaces())
-        XCTAssertEqual(accessor.text, "text", "access element text")
-
-        var element = accessor["ChildElement"].first
-        XCTAssertEqual(element.text, nil, "does not find element without ignoring namespace")
-
-        XML.ignoreNamespaces = true
-
-        element = accessor["ChildElement"].first
-        XCTAssertEqual(element.text, "childText1", "access text for first child element ignoring namespace")
-
-        element = accessor["ChildElement"].last
-        XCTAssertEqual(element.text, "childText2", "access text for last child element ignoring namespace")
-
-        XCTAssertEqual(accessor["ChildElement"].all?.count, 2)
-
-        XCTAssertEqual(
-            try XML.document(accessor),
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><env:RootElement key=\"value\">text<ns1:ChildElement>childText1</ns1:ChildElement><ns2:ChildElement>childText2</ns2:ChildElement></env:RootElement>",
-            "end document preserves elements with namespaces"
-        )
-    }
-
     func testAppend() throws {
         let accessor = XML.Accessor(singleElement())
 
@@ -508,13 +483,6 @@ class AccessorTests: XCTestCase {
         return XML.Element(name: "RootElement", text: "text", attributes: ["key": "value"], childElements: [
             XML.Element(name: "ChildElement"),
             XML.Element(name: "ChildElement")
-        ])
-    }
-
-    fileprivate func singleElementWithNamespaces() -> XML.Element {
-        return XML.Element(name: "env:RootElement", text: "text", attributes: ["key": "value"], childElements: [
-            XML.Element(name: "ns1:ChildElement", text: "childText1"),
-            XML.Element(name: "ns2:ChildElement", text: "childText2"),
         ])
     }
 

--- a/SwiftyXMLParserTests/ConverterTests.swift
+++ b/SwiftyXMLParserTests/ConverterTests.swift
@@ -116,6 +116,32 @@ class ConverterTests: XCTestCase {
             XCTAssertEqual(result, extpected)
         }
     }
+
+    func testMakeDocumentWithoutAttributes() throws {
+        let element = XML.Element(name: "name")
+        let converter = XML.Converter(XML.Accessor(element))
+
+        XCTAssertEqual(
+            try converter.makeDocument(),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><name></name>",
+            "convert xml document without extra spaces when no attributes are provided"
+        )
+
+        let element2 = XML.Element(name: "name",
+                                   text: "text",
+                                   attributes: ["key": "value"],
+                                   childElements: [
+                                    XML.Element(name: "name1"),
+                                    XML.Element(name: "name2", text: "text2")
+                                   ])
+        let converter2 = XML.Converter(XML.Accessor(element2))
+
+        XCTAssertEqual(
+            try converter2.makeDocument(),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><name key=\"value\">text<name1></name1><name2>text2</name2></name>",
+            "convert xml document with child elements without extra spaces when no attributes are provided"
+        )
+    }
 }
 
 extension XML.Element {

--- a/SwiftyXMLParserTests/ConverterTests.swift
+++ b/SwiftyXMLParserTests/ConverterTests.swift
@@ -142,6 +142,28 @@ class ConverterTests: XCTestCase {
             "convert xml document with child elements without extra spaces when no attributes are provided"
         )
     }
+
+    func testMakeWithoutDeclaration() throws {
+        let element = XML.Element(name: "name")
+        let converter = XML.Converter(XML.Accessor(element))
+
+        XCTAssertEqual(
+            try converter.makeDocument(withDeclaration: false),
+            "<name></name>",
+            "convert xml document without xml declaration header"
+        )
+
+        let element2 = XML.Element(name: "name",
+                                   text: "text",
+                                   attributes: ["key": "value"])
+        let converter2 = XML.Converter(XML.Accessor(element2))
+
+        XCTAssertEqual(
+            try converter2.makeDocument(withDeclaration: false),
+            "<name key=\"value\">text</name>",
+            "convert xml document without xml declaration header"
+        )
+    }
 }
 
 extension XML.Element {

--- a/SwiftyXMLParserTests/ConverterTests.swift
+++ b/SwiftyXMLParserTests/ConverterTests.swift
@@ -165,15 +165,3 @@ class ConverterTests: XCTestCase {
         )
     }
 }
-
-extension XML.Element {
-    convenience init(name: String,
-                     text: String? = nil,
-                     attributes: [String: String] = [String: String](),
-                     childElements: [XML.Element] = [XML.Element]()) {
-        self.init(name: name)
-        self.text = text
-        self.attributes = attributes
-        self.childElements = childElements
-    }
-}

--- a/SwiftyXMLParserTests/ParserTests.swift
+++ b/SwiftyXMLParserTests/ParserTests.swift
@@ -145,6 +145,24 @@ class ParserTests: XCTestCase {
             XCTAssert(false, "fail")
         }
     }
+
+    func testIgnoreNamespaces() {
+        let data = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <env:RootElement key="value">
+                <ns1:ChildElement>childText1</ns1:ChildElement>
+                <ns2:ChildElement>childText2</ns2:ChildElement>
+            </env:RootElement>
+        """.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8)!
+
+        let xml = XML.Parser().parse(data)
+        XCTAssertEqual(xml["env:RootElement", "ns1:ChildElement"].text, "childText1", "can access element when including namespace")
+        XCTAssertEqual(xml["RootElement", "ChildElement"].first.text, nil, "cannot find elements with namespaces")
+
+        let xmlIgnoreNamespaces = XML.Parser(ignoreNamespaces: true).parse(data)
+        XCTAssertEqual(xmlIgnoreNamespaces["RootElement", "ChildElement"].first.text, "childText1", "can find element when ignoring namespaces")
+        XCTAssertEqual(xmlIgnoreNamespaces["RootElement", "ChildElement"].last.text, "childText2", "can find element when ignoring namespaces")
+    }
     
     func testParseErrorToInvalidCharacter() {
         let str = "<xmlopening>@ß123\u{1c}</xmlopening>"

--- a/SwiftyXMLParserTests/XMLTests.swift
+++ b/SwiftyXMLParserTests/XMLTests.swift
@@ -57,7 +57,20 @@ class XMLTests: XCTestCase {
             XCTFail("fail to generate data")
         }
     }
-    
+
+    func testParseWithArguments() {
+        if let data = try? Data(contentsOf: URL(fileURLWithPath: getPath("XMLDocument.xml"))) {
+            let xml = XML.parse(data, trimming: .whitespacesAndNewlines, ignoreNamespaces: true)
+            if  let _ = xml["ResultSet"].error {
+                XCTFail("fail to parse")
+
+            } else {
+                XCTAssert(true, "sucess to Parse")
+            }
+        } else {
+            XCTFail("fail to generate data")
+        }
+    }
     
     func testSuccessParseFromString() {
         if let string = try? String(contentsOfFile: getPath("XMLDocument.xml"), encoding: String.Encoding.utf8),
@@ -71,7 +84,6 @@ class XMLTests: XCTestCase {
             XCTFail("fail to parse")
         }
     }
-    
     
     func testSuccessParseFromDoublebyteSpace() {
         guard let xml = try? XML.parse("<Name>　</Name>") else {


### PR DESCRIPTION
This PR covers the following 3 features. Might have been better to split it in 3 pull requests, but let us see if we can go through them one by one and I will make the necessary adjustments:

Feature 1: Ability to get and **set** text and attributes on single element using the Accessor, and keep the modified elements when creating an xml document. The same small change could also be applied to other types than text/string. It requires that the accessor is not created as a constant.

```swift

var accessor = XML.Accessor(singleElement())
accessor.text = "text2"
XCTAssertEqual(accessor.text, "text2", "set text on first single element")
```

Feature 2: Ability to append a new element to an accessor.

```swift
let accessor = XML.Accessor(singleElement())
accessor.append(singleElement())
XCTAssertEqual(accessor["RootElement"].text, "text", "check newly added element")
```

Feature 3: Global flag for ignoring namespaces when accessing elements. Currently I am using this framework with SOAP XML, which has dynamically prefixed namespaces on all elements.

```xml
<?xml version=\"1.0\" encoding=\"UTF-8\"?>
<env:RootElement key=\"value\">
  <ns1:ChildElement>childText1</ns1:ChildElement>
  <ns2:ChildElement>childText2</ns2:ChildElement>
</env:RootElement>
```

```swift
let accessor = XML.Accessor(xmlFromAbove())
XML.ignoreNamespaces = true
XCTAssertEqual(accessor["ChildElement"].first.text, "childText1", "access text for first child element ignoring namespace")
```

Bugfix 1: XML documents are created with an extra space when no attributes are added for an element.
Bugfix 2: XML declaration prefix is not optional.
Bugfix 3: XML Element does not have a full initialiser.

All 3 features have corresponding unit tests. Let me know what you think.