### PR TITLE
Escape characters when making XML document

### DIFF
--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -538,7 +538,7 @@ extension XML {
                     ["&", "&amp;"],
                     ["<", "&lt;"],
                     [">", "&gt;"]
-                ];
+                ]
                 return charactersToEscape.reduce(string) {
                     $0.replacingOccurrences(of: $1[0], with: $1[1], options: .literal, range: nil)
                 }

--- a/SwiftyXMLParser/Accessor.swift
+++ b/SwiftyXMLParser/Accessor.swift
@@ -519,7 +519,7 @@ extension XML {
 
         private func traverse(_ element: Element) -> String {
             let name = element.name
-            let text = element.text ?? ""
+            let text = escapeXMLCharacters(element.text ?? "")
             let attrs = element.attributes.map { (k, v) in "\(k)=\"\(v)\"" }.joined(separator: " ")
 
             let childDocs = element.childElements.reduce("", { (result, element) in
@@ -531,6 +531,17 @@ extension XML {
             } else {
                 return "<\(name)\(attrs.isEmpty ? "" : " ")\(attrs)>\(text)\(childDocs)</\(name)>"
             }
+        }
+
+        private func escapeXMLCharacters(_ string: String) -> String {
+                let charactersToEscape = [
+                    ["&", "&amp;"],
+                    ["<", "&lt;"],
+                    [">", "&gt;"]
+                ];
+                return charactersToEscape.reduce(string) {
+                    $0.replacingOccurrences(of: $1[0], with: $1[1], options: .literal, range: nil)
+                }
         }
     }
 }

--- a/SwiftyXMLParserTests/ConverterTests.swift
+++ b/SwiftyXMLParserTests/ConverterTests.swift
@@ -117,6 +117,19 @@ class ConverterTests: XCTestCase {
         }
     }
 
+    func testMakeDocumentEscapingCharacters() throws {
+        let element = XML.Element(name: "name", text: "me&you", childElements: [
+            XML.Element(name: "child", text: "& < > &")
+        ])
+        let converter = XML.Converter(XML.Accessor(element))
+
+        XCTAssertEqual(
+            try converter.makeDocument(),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><name>me&amp;you<child>&amp; &lt; &gt; &amp;</child></name>",
+            "escape characters when making xml document"
+        )
+    }
+
     func testMakeDocumentWithoutAttributes() throws {
         let element = XML.Element(name: "name")
         let converter = XML.Converter(XML.Accessor(element))


### PR DESCRIPTION
**Issue:** Making a xml document which includes characters `&`, `<` or `>`, produces invalid XML, because these characters need to be escaped according to the XML specification.

**Fix:** Escape these characters in text when traversing the xml elements. Issues can still occur when using these characters inside names and attributes, but they are most common in text.

**Ref.:** https://www.w3.org/TR/xml/